### PR TITLE
Add time so relative date works on day of ride

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,9 +1,9 @@
 <?php
 function nextLastFriday()
 {
-    $lastFridayThisMonth = strtotime('last friday of this month');
+    $lastFridayThisMonth = strtotime('last friday of this month 7pm');
 
-    return $lastFridayThisMonth > time() ? $lastFridayThisMonth : strtotime('last friday of next month');
+    return $lastFridayThisMonth > time() ? $lastFridayThisMonth : strtotime('last friday of next month 7pm');
 
 }
 $nextCriticalMass = date('F jS', nextLastFriday());


### PR DESCRIPTION
Hey, thanks for starting this! I ran [criticalmasswinnipeg.net](https://web.archive.org/web/20071226091651/https://criticalmasswinnipeg.net/) long ago but haven’t been able to face getting a site back up.

I noticed that the site wasn’t showing today’s ride:

<img width="569" alt="Critical Mass Winnipeg @ Last Friday 2022-08-26 09-32-31" src="https://user-images.githubusercontent.com/43280/186927943-2ccd91ae-b0ed-474e-90ea-38d7e6171e43.png">

I’m not a PHP-knower but I tried this locally and it seemed to work. It also showed the correct date for next month when I changed the clock to 9pm tonight. I imagine the server time zone might play a role too 🤔